### PR TITLE
Add url to major mode for emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ article
 * [Syntax highlighting for Atom](https://github.com/nin-jin/atom-language-tree)
 * [Syntax highlighting for Visual Studio Code](https://github.com/nin-jin/vscode-language-tree)
 * [Syntax highlighting for Sublime](https://github.com/yurybikuzin/Smol-sublime)
+* [Syntax highlighting for Emacs](https://github.com/osv/mol-tree-mode)
 
 ## Other implementations
 


### PR DESCRIPTION
Add to the readme link to Emacs's syntax highlighter

https://github.com/osv/mol-tree-mode
 
![screenshot](https://user-images.githubusercontent.com/213405/122896720-06cfe900-d352-11eb-9a41-9ff1091360ee.png)
